### PR TITLE
Fix errore download dopo aggiornamento app RaiPlay.

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.raitv"
        name="Rai Play"
-       version="3.0.1"
+       version="3.0.2"
        provider-name="Nightflyer, cttynul, maxbambi">
   <requires>
     <import addon="xbmc.python" version="2.1.0"/>

--- a/default.py
+++ b/default.py
@@ -141,7 +141,7 @@ def play(url, pathId="", srt=[]):
         else:
             raiplay = RaiPlay()
             metadata = raiplay.getVideoMetadata(pathId)
-            url = metadata["contentUrl"]
+            url = metadata["content_url"]
             srtUrl = metadata["subtitles"]
             
         if srtUrl != "":

--- a/resources/lib/raiplay.py
+++ b/resources/lib/raiplay.py
@@ -92,6 +92,7 @@ class RaiPlay:
         return response["video"]
     
     def getUrl(self, pathId):
+        pathId = pathId[:-9] + pathId[-9:].replace("html?json", "json")
         pathId = pathId.replace(" ", "%20")
         if pathId[0:2] == "//":
             url = "http:" + pathId


### PR DESCRIPTION
Fix errore download dopo aggiornamento app RaiPlay su Android,
alla versione 3.0.2, del 2 novembre 2019.